### PR TITLE
Update signature-pad.blade.php

### DIFF
--- a/resources/views/forms/components/fields/signature-pad.blade.php
+++ b/resources/views/forms/components/fields/signature-pad.blade.php
@@ -29,7 +29,7 @@
 
             <div class="flex mt-2 justify-end space-x-2">
                 <x-filament::button color="danger"  outlined="true" size="sm" @click.prevent="clear()">Clear</x-filament::button>
-                @if(!$isDownloadDisabled())
+                @if(!$isDisabledDownload())
                     <x-filament::button color="primary" outlined="true" size="sm" icon="heroicon-o-download" @click.prevent="downloadSVG()">.svg</x-filament::button>
                     <x-filament::button color="primary" outlined="true" size="sm" icon="heroicon-o-download" @click.prevent="downloadPNG()">.png</x-filament::button>
                     <x-filament::button color="primary" outlined="true" size="sm" icon="heroicon-o-download" @click.prevent="downloadJPG()">.jpg</x-filament::button>


### PR DESCRIPTION
Fix variable name for last PR to disable downloads

In the file
https://github.com/savannabits/filament-signature-pad/blob/main/src/Forms/Concerns/HasSignaturePadAttributes.php

The function name is **isDisabledDownload** not **isDownloadDisabled**