### PR TITLE
Display template or not, settable

### DIFF
--- a/resources/views/forms/components/fields/signature-pad.blade.php
+++ b/resources/views/forms/components/fields/signature-pad.blade.php
@@ -12,6 +12,7 @@
     $suffixIcon = $getSuffixIcon();
     $suffixLabel = $getSuffixLabel();
     $statePath = $getStatePath();
+    $displayTemplate = $canDisplayTemplate();
 @endphp
 <x-dynamic-component
     :component="$getFieldWrapperView()"
@@ -36,9 +37,11 @@
             id: '{{ $id }}',
         })"
         class="p-2 md:p-4 bg-white dark:bg-gray-500 sm:rounded-md">
-        <template x-if="state">
-            <img class="border mx-auto dark:border-gray-700 rounded-lg w-full max-w-[800px]" alt="current_signature" :src="state">
-        </template>
+        @if($displayTemplate)
+            <template x-if="state">
+                <img class="border mx-auto dark:border-gray-700 rounded-lg w-full max-w-[800px]" alt="current_signature" :src="state">
+            </template>
+        @endif
         @if(!($isReadOnly() || $isDisabled))
             <canvas
                 before="Hello World"

--- a/resources/views/forms/components/fields/signature-pad.blade.php
+++ b/resources/views/forms/components/fields/signature-pad.blade.php
@@ -12,7 +12,7 @@
     $suffixIcon = $getSuffixIcon();
     $suffixLabel = $getSuffixLabel();
     $statePath = $getStatePath();
-    $displayTemplate = $canDisplayTemplate();
+    $displayTemplate = $getDisplayTemplate();
 @endphp
 <x-dynamic-component
     :component="$getFieldWrapperView()"

--- a/src/Forms/Components/Fields/SignaturePad.php
+++ b/src/Forms/Components/Fields/SignaturePad.php
@@ -2,6 +2,7 @@
 
 namespace Coolsam\SignaturePad\Forms\Components\Fields;
 
+use Coolsam\SignaturePad\Forms\Concerns\CanDisplayTemplate;
 use Coolsam\SignaturePad\Forms\Concerns\HasSignaturePadAttributes;
 use Filament\Forms\Components\Concerns;
 use Filament\Forms\Components\Contracts;
@@ -20,6 +21,7 @@ class SignaturePad extends Field implements Contracts\CanBeLengthConstrained, Co
     use Concerns\HasInputMode;
     use Concerns\HasPlaceholder;
     use HasExtraAlpineAttributes;
+    use CanDisplayTemplate;
 
     const PACKAGE_NAME = 'coolsam/signature-pad';
 

--- a/src/Forms/Concerns/CanDisplayTemplate.php
+++ b/src/Forms/Concerns/CanDisplayTemplate.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Coolsam\SignaturePad\Forms\Concerns;
+
+use Closure;
+
+trait CanDisplayTemplate
+{
+    protected bool | Closure | null $displayTemplate = true;
+
+    /**
+     * @param bool $displayTemplate
+     * @return CanDisplayTemplate
+     */
+    public function displayTemplate(bool $displayTemplate = true): static
+    {
+        $this->displayTemplate = $displayTemplate;
+
+        return $this;
+    }
+
+    public function getDisplayTemplate(): ?float
+    {
+        return $this->evaluate($this->displayTemplate);
+    }
+}


### PR DESCRIPTION
Hello, this little PR allow the dev to display or not the template. 

```php
SignaturePad::make('signature')
                    ->displayTemplate(false)
```